### PR TITLE
🗃️ Use `@parcel/watcher` instead of Deno

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -18,7 +18,7 @@ jobs:
         # continue-on-error: true
         strategy:
             matrix:
-                julia-version: ["1.6"]
+                julia-version: ["1.6", "1.7"]
                 os: [ubuntu-latest, macOS-latest, windows-latest]
 
         steps:

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.4"
 [deps]
 Deno_jll = "04572ae6-984a-583e-9378-9577a1c2574d"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+libwatcher_jll = "f2e3f4ed-6d30-53f6-bb33-6a6ab454fa9c"
 
 [compat]
 Deno_jll = "^1.10"
@@ -17,4 +18,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,9 @@ authors = ["Fons van der Plas <fons@plutojl.org>"]
 version = "0.1.5"
 
 [deps]
-Deno_jll = "04572ae6-984a-583e-9378-9577a1c2574d"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 libwatcher_jll = "f2e3f4ed-6d30-53f6-bb33-6a6ab454fa9c"
 
 [compat]
-Deno_jll = "^1.10"
-JSON = "^0.20, ^0.21"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ watch_folder(f::Function, dir=".")
 Watch a folder recursively for any changes. Includes changes to file contents. A [`FileEvent`](@ref) is passed to the callback function `f`.
 
 ## Examples
-=======
+
 ```julia
 watch_file(f::Function, filename=".")
 ```

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ schedule(watch_task, InterruptException(); error=true)
 The library also allow you take snapshots of a directory and read those snapshots later to see exactly which files have been updated/deleted/created.
 
 ```julia
-options = BetterFileWatching.Options(ignores = Set{String}(["./.git"]))
-BetterFileWatching.write_snapshot(dir, snapshot_path; options = options)
+options = Options(ignores = Set{String}(["./.git"]))
+write_snapshot(dir, snapshot_path; options = options)
 
-# Create some, do some changes, delete some files...
+# Create some files, do some changes;, delete some files...
 
-events = BetterFileWatching.get_events_since(dir, snapshot_path; options = options)
+events = get_events_since(dir, snapshot_path; options = options)
 ```
 
 ## Differences with the FileWatching stdlib

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ watch_folder(f::Function, dir=".")
 
 Watch a folder recursively for any changes. Includes changes to file contents. A [`FileEvent`](@ref) is passed to the callback function `f`.
 
-# Example
+## Examples
 
 ```julia
 watch_folder(".") do event
@@ -27,8 +27,22 @@ sleep(5)
 schedule(watch_task, InterruptException(); error=true)
 ```
 
-# Differences with the FileWatching stdlib
+## Snapshots
+
+The library also allow you take snapshots of a directory and read those snapshots later to see exactly which files have been updated/deleted/created.
+
+```julia
+options = BetterFileWatching.Options(ignores = Set{String}(["./.git"]))
+BetterFileWatching.write_snapshot(dir, snapshot_path; options = options)
+
+# Create some, do some changes, delete some files...
+
+events = BetterFileWatching.get_events_since(dir, snapshot_path; options = options)
+```
+
+## Differences with the FileWatching stdlib
 
 -   `BetterFileWatching.watch_folder` works _recursively_, i.e. subfolders are also watched.
 -   `BetterFileWatching.watch_folder` also watching file _contents_ for changes.
--   BetterFileWatching.jl is just a small wrapper around [`Deno.watchFs`](https://doc.deno.land/builtin/stable#Deno.watchFs), made available through the [Deno_jll](https://github.com/JuliaBinaryWrappers/Deno_jll.jl) package. `Deno.watchFs` is well-tested and widely used.
+-   BetterFileWatching.jl is just a wrapper around a port of [parcel-bundler/watcher](https://github.com/parcel-bundler/watcher) to Julia (available on [JuliaPluto/watcher](https://github.com/JuliaPluto/watcher))
+

--- a/src/BetterFileWatching.jl
+++ b/src/BetterFileWatching.jl
@@ -36,6 +36,7 @@ function convert_to_deno_events(events::Vector{Event})
 end
 
 export watch_folder, watch_file
+export Options, write_snapshot, get_events_since
 
 function _doc_examples(folder)
     f = folder ? "folder" : "file"

--- a/src/libwatcher.jl
+++ b/src/libwatcher.jl
@@ -1,5 +1,4 @@
-libwatcher = "/home/paul/Projects/watcher/build/libwatcher.so"
-include_dependency(libwatcher)
+using libwatcher_jll
 
 mutable struct VariableSize{N}
     data::NTuple{N,UInt8}

--- a/src/libwatcher.jl
+++ b/src/libwatcher.jl
@@ -1,201 +1,230 @@
-libwatcher = "/home/paul/Projects/watcher/zig-out/lib/libwatcher.so"
+libwatcher = "/home/paul/Projects/watcher/build/libwatcher.so"
 
 mutable struct Watcher
-	cond::Base.AsyncCondition
-  watcher::Ptr{Nothing}
+    cond::Base.AsyncCondition
+    chan::Channel{Nothing}
+    watcher::Ptr{Nothing}
 
-  dir::AbstractString
+    dir::String
+
+    Watcher(cond::Base.AsyncCondition, chan::Channel{Nothing}, watcher::Ptr{Nothing}, dir::AbstractString) =
+        finalizer(watcher_unsubscribe, new(cond, chan, watcher, dir))
 end
 Watcher(f::Function, ptr, dir::AbstractString) = Watcher(Base.AsyncCondition(f), ptr, dir)
 
 Base.show(io::IO, w::Watcher) = write(io, "Watcher(\"", w.dir, "\")")
 
 Base.@kwdef struct Options
-	ignores::Set{String} = Set{String}()
-	backend = "default"
+    ignores::Set{String} = Set{String}()
+    backend = "default"
 end
 
 function watcher_write_snapshot(dir, snapshot_path)
-	@ccall libwatcher.watcher_write_snapshot(dir::Cstring, snapshot_path::Cstring)::Cvoid
+    @ccall libwatcher.watcher_write_snapshot(dir::Cstring, snapshot_path::Cstring)::Cvoid
 end
 
-function watcher_get_events_since(dir, snapshot_path, callback)
-	@ccall libwatcher.watcher_get_events_since(dir::Cstring, snapshot_path::Cstring, callback::Ptr{Nothing})::Cvoid
+function watcher_get_events_since(dir, snapshot_path, events)
+    @ccall libwatcher.watcher_get_events_since(
+        dir::Cstring,
+        snapshot_path::Cstring,
+        events::Ptr{Nothing},
+    )::Cvoid
 end
 
 function watcher_subscribe(dir, handle)
-	@ccall libwatcher.watcher_subscribe(dir::Cstring, handle::Ptr{Nothing})::Cvoid
+    @ccall libwatcher.watcher_subscribe(dir::Cstring, handle::Ptr{Nothing})::Cvoid
 end
 watcher_subscribe(w::Watcher) = watcher_subscribe(w.dir, w.cond.handle)
 
 function watcher_unsubscribe(dir)
-	@ccall libwatcher.watcher_unsubscribe(dir::Cstring)::Cvoid
+    @ccall libwatcher.watcher_unsubscribe(dir::Cstring)::Cvoid
 end
-watcher_unsubscribe(w::Watcher) = watcher_unsubscribe(w.dir)
+
+function watcher_unsubscribe(watcher::Watcher)
+    if isopen(watcher.cond)
+        take!(watcher.chan)
+        isopen(watcher.cond) || return
+
+        watcher_unsubscribe(watcher.dir) # FIXME: use watcher instead of dir
+        Base.close(watcher.cond)
+    end
+
+    nothing
+end
 
 function watcher_get_watcher(dir, options)
-  @ccall libwatcher.watcher_get_watcher(dir::Cstring, options::Ptr{Nothing})::Ptr{Nothing}
+    @ccall libwatcher.watcher_get_watcher(dir::Cstring, options::Ptr{Nothing})::Ptr{Nothing}
+end
+
+function watcher_delete_watcher(watcher)
+    @ccall libwatcher.watcher_delete_watcher(watcher::Ptr{Nothing})::Cvoid
 end
 
 function watcher_watcher_get_events(watcher, events)
-  @ccall libwatcher.watcher_watcher_get_events(watcher::Ptr{Nothing}, events::Ptr{Nothing})::Ptr{Nothing}
+    @ccall libwatcher.watcher_watcher_get_events(
+        watcher::Ptr{Nothing},
+        events::Ptr{Nothing},
+    )::Ptr{Nothing}
 end
 
 function to_options_ptr(options)
-  options_ptr = @ccall libwatcher.watcher_new_options()::Ptr{Nothing}
-  for ignore in options.ignores
-    @ccall libwatcher.watcher_options_add_ignore(options_ptr::Ptr{Nothing}, ignore::Cstring)::Ptr{Nothing}
-  end
-  @ccall libwatcher.watcher_options_set_backend(options_ptr::Ptr{Nothing}, options.backend::Cstring)::Ptr{Nothing}
+    options_ptr = @ccall libwatcher.watcher_new_options()::Ptr{Nothing}
+    for ignore in options.ignores
+        @ccall libwatcher.watcher_options_add_ignore(
+            options_ptr::Ptr{Nothing},
+            ignore::Cstring,
+        )::Ptr{Nothing}
+    end
+    @ccall libwatcher.watcher_options_set_backend(
+        options_ptr::Ptr{Nothing},
+        options.backend::Cstring,
+    )::Ptr{Nothing}
 
-  options_ptr
+    options_ptr
 end
 
 function watcher_delete_options(options)
-  @ccall libwatcher.watcher_delete_options(options::Ptr{Nothing})::Cvoid
+    @ccall libwatcher.watcher_delete_options(options::Ptr{Nothing})::Cvoid
 end
 
 struct JLEvent
-	path::Ptr{Int8}
-	path_length::Csize_t
-	is_created::Bool
-	is_deleted::Bool
+    path::Ptr{Cchar}
+    path_length::Csize_t
+    is_created::Bool
+    is_deleted::Bool
 end
 
 struct Event
-	path::String
-	is_created::Bool
-	is_deleted::Bool
+    path::String
+    is_created::Bool
+    is_deleted::Bool
 end
 Event(jl_event::JLEvent) = Event(
-  Base.unsafe_string(jl_event.path, jl_event.path_length),
-  jl_event.is_created,
-  jl_event.is_deleted
+    Base.unsafe_string(jl_event.path, jl_event.path_length),
+    jl_event.is_created,
+    jl_event.is_deleted,
 )
 
-const global_watchers = Dict{String,Watcher}()
-
-function _subscribe_callback(f)
-	function _c_callback(cevents::Ptr{JLEvent}, n_events::Csize_t)
-		events = Event[]
-
-		if cevents == C_NULL
-			f(Event[])
-			return nothing
-		end
-
-		for i in 0:n_events-1
-			jl_event = Base.unsafe_load(cevents + i * sizeof(JLEvent))
-			if jl_event.path_length == 0
-        @warn "got path of length 0"
-        continue
-      end
-			push!(events, Event(jl_event))
-		end
-
-		@async f(events)
-
-		nothing
-	end
-
-	@cfunction($_c_callback, Cvoid, (Ptr{JLEvent}, Csize_t))
-end
-
 function sanitize_path(path)
-	length(path) == 0 && error("path can't be empty")
-	path # TODO
+    length(path) == 0 && error("path can't be empty")
+    path # TODO
 end
 
 mutable struct Events
-  size::Csize_t
-  events::Ptr{JLEvent}
+    size::Csize_t
+    events::Ptr{JLEvent}
 end
 Events() = Events(0, Ptr{JLEvent}())
 
 function _get_events(watcher_ptr)
-  events = Events()
-  watcher_watcher_get_events(watcher_ptr, Base.pointer_from_objref(events))
-  events.events == C_NULL && error("Failed to fetch events from watcher.")
+    events = Events()
+    GC.@preserve events watcher_watcher_get_events(
+        watcher_ptr,
+        Base.pointer_from_objref(events),
+    )
+    events.events == C_NULL && error("Failed to fetch events from watcher.")
 
-  Base.unsafe_wrap(Array, events.events, events.size; own=true)
+    raw_events = Base.unsafe_wrap(Array, events.events, events.size; own = true)
+
+    map(raw_events) do raw_event
+        event = Event(raw_event)
+        ccall(:free, Cvoid, (Ptr{Nothing},), raw_event.path)
+        event
+    end
 end
 
-function subscribe(f::Function, dir, options=Options())
-	dir = sanitize_path(dir)
+function subscribe(f::Function, dir, options = Options())
+    dir = sanitize_path(dir)
 
-  options_ptr = to_options_ptr(options)
-  watcher_ptr = watcher_get_watcher(dir, options_ptr);
-  watcher_delete_options(options_ptr)
+    options_ptr = to_options_ptr(options)
+    watcher_ptr = watcher_get_watcher(dir, options_ptr)
+    watcher_delete_options(options_ptr)
 
-  function callback(_)
-    try
-      events = Event.(_get_events(watcher_ptr))
-      f(events)
-    catch err
-      @error "something went wrong" err
+    chan = Channel{Nothing}(1)
+    put!(chan, nothing)
+
+    function callback(_)
+        try
+            take!(chan)
+            events = _get_events(watcher_ptr)
+            put!(chan, nothing)
+
+            f(events)
+        catch err
+            @error "something went wrong" err
+        end
     end
-  end
 
-  cond = Base.AsyncCondition(callback)
-	watcher = Watcher(cond, watcher_ptr, dir)
+    cond = Base.AsyncCondition(callback)
+    watcher = Watcher(cond, chan, watcher_ptr, dir)
 
-	watcher_subscribe(watcher)
+    watcher_subscribe(watcher)
 
-	watcher
+    watcher
 end
 
 function unsubscribe(watcher)
-	watcher_unsubscribe(watcher)
+    watcher_unsubscribe(watcher)
 
-	delete!(global_watchers, watcher.dir)
-	nothing
+    nothing
 end
 
 function write_snapshot(dir, snapshot_path)
-	dir = sanitize_path(dir)
+    dir = sanitize_path(dir)
 
-	watcher_write_snapshot(dir, snapshot_path);
+    watcher_write_snapshot(dir, snapshot_path)
 end
 
 function get_events_since(dir, snapshot)
-	dir = sanitize_path(dir)
+    dir = sanitize_path(dir)
 
-	events_ref = Ref{Vector{Event}}(Event[])
-	callback = _subscribe_callback() do events
-		events_ref[] = events
-	end
+    events = Events()
+    GC.@preserve events watcher_get_events_since(
+        dir,
+        snapshot,
+        Base.pointer_from_objref(events),
+    )
+    events.events == C_NULL && error("Failed to get events since for '$snapshot'")
 
-	GC.@preserve callback watcher_get_events_since(dir, snapshot, callback)
-
-	events_ref[]
+    Base.unsafe_wrap(Array, events.events, events.size; own = true)
 end
 
 "Synchronous API"
-function watch(f::Function, dir::AbstractString, options=Options())
-  dir = sanitize_path(dir)
+function watch(f::Function, dir::AbstractString, options = Options())
+    dir = sanitize_path(dir)
 
-  options_ptr = to_options_ptr(options)
-  watcher_ptr = watcher_get_watcher(dir, options_ptr)
-  watcher_delete_options(options_ptr)
+    options_ptr = to_options_ptr(options)
+    watcher_ptr = watcher_get_watcher(dir, options_ptr)
+    watcher_delete_options(options_ptr)
 
-  cond = Base.AsyncCondition()
-  w = Watcher(cond, watcher_ptr, dir)
+    cond = Base.AsyncCondition()
+    chan = Channel{Nothing}(1)
+    put!(chan, nothing)
+    w = Watcher(cond, chan, watcher_ptr, dir)
 
-  task = Task() do
-    try
-      while true
-	wait(cond)
+    task = Task() do
+        try
+            while isopen(cond)
+                wait(cond)
 
-	events = Event.(_get_events(watcher_ptr))
-	f(events)
-      end
-    finally
-      unsubscribe(w)
+                take!(chan)
+                events = _get_events(watcher_ptr)
+                put!(chan, nothing)
+                f(events)
+            end
+        finally
+            unsubscribe(w)
+        end
     end
-  end
 
-  watcher_subscribe(w)
+    watcher_subscribe(w)
 
-  schedule(task)
-  wait(task)
+    schedule(task)
+
+    try
+        wait(task)
+    catch
+    end
+
+    nothing
 end

--- a/src/libwatcher.jl
+++ b/src/libwatcher.jl
@@ -1,0 +1,201 @@
+libwatcher = "/home/paul/Projects/watcher/zig-out/lib/libwatcher.so"
+
+mutable struct Watcher
+	cond::Base.AsyncCondition
+  watcher::Ptr{Nothing}
+
+  dir::AbstractString
+end
+Watcher(f::Function, ptr, dir::AbstractString) = Watcher(Base.AsyncCondition(f), ptr, dir)
+
+Base.show(io::IO, w::Watcher) = write(io, "Watcher(\"", w.dir, "\")")
+
+Base.@kwdef struct Options
+	ignores::Set{String} = Set{String}()
+	backend = "default"
+end
+
+function watcher_write_snapshot(dir, snapshot_path)
+	@ccall libwatcher.watcher_write_snapshot(dir::Cstring, snapshot_path::Cstring)::Cvoid
+end
+
+function watcher_get_events_since(dir, snapshot_path, callback)
+	@ccall libwatcher.watcher_get_events_since(dir::Cstring, snapshot_path::Cstring, callback::Ptr{Nothing})::Cvoid
+end
+
+function watcher_subscribe(dir, handle)
+	@ccall libwatcher.watcher_subscribe(dir::Cstring, handle::Ptr{Nothing})::Cvoid
+end
+watcher_subscribe(w::Watcher) = watcher_subscribe(w.dir, w.cond.handle)
+
+function watcher_unsubscribe(dir)
+	@ccall libwatcher.watcher_unsubscribe(dir::Cstring)::Cvoid
+end
+watcher_unsubscribe(w::Watcher) = watcher_unsubscribe(w.dir)
+
+function watcher_get_watcher(dir, options)
+  @ccall libwatcher.watcher_get_watcher(dir::Cstring, options::Ptr{Nothing})::Ptr{Nothing}
+end
+
+function watcher_watcher_get_events(watcher, events)
+  @ccall libwatcher.watcher_watcher_get_events(watcher::Ptr{Nothing}, events::Ptr{Nothing})::Ptr{Nothing}
+end
+
+function to_options_ptr(options)
+  options_ptr = @ccall libwatcher.watcher_new_options()::Ptr{Nothing}
+  for ignore in options.ignores
+    @ccall libwatcher.watcher_options_add_ignore(options_ptr::Ptr{Nothing}, ignore::Cstring)::Ptr{Nothing}
+  end
+  @ccall libwatcher.watcher_options_set_backend(options_ptr::Ptr{Nothing}, options.backend::Cstring)::Ptr{Nothing}
+
+  options_ptr
+end
+
+function watcher_delete_options(options)
+  @ccall libwatcher.watcher_delete_options(options::Ptr{Nothing})::Cvoid
+end
+
+struct JLEvent
+	path::Ptr{Int8}
+	path_length::Csize_t
+	is_created::Bool
+	is_deleted::Bool
+end
+
+struct Event
+	path::String
+	is_created::Bool
+	is_deleted::Bool
+end
+Event(jl_event::JLEvent) = Event(
+  Base.unsafe_string(jl_event.path, jl_event.path_length),
+  jl_event.is_created,
+  jl_event.is_deleted
+)
+
+const global_watchers = Dict{String,Watcher}()
+
+function _subscribe_callback(f)
+	function _c_callback(cevents::Ptr{JLEvent}, n_events::Csize_t)
+		events = Event[]
+
+		if cevents == C_NULL
+			f(Event[])
+			return nothing
+		end
+
+		for i in 0:n_events-1
+			jl_event = Base.unsafe_load(cevents + i * sizeof(JLEvent))
+			if jl_event.path_length == 0
+        @warn "got path of length 0"
+        continue
+      end
+			push!(events, Event(jl_event))
+		end
+
+		@async f(events)
+
+		nothing
+	end
+
+	@cfunction($_c_callback, Cvoid, (Ptr{JLEvent}, Csize_t))
+end
+
+function sanitize_path(path)
+	length(path) == 0 && error("path can't be empty")
+	path # TODO
+end
+
+mutable struct Events
+  size::Csize_t
+  events::Ptr{JLEvent}
+end
+Events() = Events(0, Ptr{JLEvent}())
+
+function _get_events(watcher_ptr)
+  events = Events()
+  watcher_watcher_get_events(watcher_ptr, Base.pointer_from_objref(events))
+  events.events == C_NULL && error("Failed to fetch events from watcher.")
+
+  Base.unsafe_wrap(Array, events.events, events.size; own=true)
+end
+
+function subscribe(f::Function, dir, options=Options())
+	dir = sanitize_path(dir)
+
+  options_ptr = to_options_ptr(options)
+  watcher_ptr = watcher_get_watcher(dir, options_ptr);
+  watcher_delete_options(options_ptr)
+
+  function callback(_)
+    try
+      events = Event.(_get_events(watcher_ptr))
+      f(events)
+    catch err
+      @error "something went wrong" err
+    end
+  end
+
+  cond = Base.AsyncCondition(callback)
+	watcher = Watcher(cond, watcher_ptr, dir)
+
+	watcher_subscribe(watcher)
+
+	watcher
+end
+
+function unsubscribe(watcher)
+	watcher_unsubscribe(watcher)
+
+	delete!(global_watchers, watcher.dir)
+	nothing
+end
+
+function write_snapshot(dir, snapshot_path)
+	dir = sanitize_path(dir)
+
+	watcher_write_snapshot(dir, snapshot_path);
+end
+
+function get_events_since(dir, snapshot)
+	dir = sanitize_path(dir)
+
+	events_ref = Ref{Vector{Event}}(Event[])
+	callback = _subscribe_callback() do events
+		events_ref[] = events
+	end
+
+	GC.@preserve callback watcher_get_events_since(dir, snapshot, callback)
+
+	events_ref[]
+end
+
+"Synchronous API"
+function watch(f::Function, dir::AbstractString, options=Options())
+  dir = sanitize_path(dir)
+
+  options_ptr = to_options_ptr(options)
+  watcher_ptr = watcher_get_watcher(dir, options_ptr)
+  watcher_delete_options(options_ptr)
+
+  cond = Base.AsyncCondition()
+  w = Watcher(cond, watcher_ptr, dir)
+
+  task = Task() do
+    try
+      while true
+	wait(cond)
+
+	events = Event.(_get_events(watcher_ptr))
+	f(events)
+      end
+    finally
+      unsubscribe(w)
+    end
+  end
+
+  watcher_subscribe(w)
+
+  schedule(task)
+  wait(task)
+end

--- a/src/libwatcher.jl
+++ b/src/libwatcher.jl
@@ -1,16 +1,37 @@
 libwatcher = "/home/paul/Projects/watcher/build/libwatcher.so"
+include_dependency(libwatcher)
+
+mutable struct VariableSize{N}
+    data::NTuple{N,UInt8}
+end
+const handle_size = Ref{Int}(-1)
+
+function WatcherHandle()
+    if handle_size[] == -1
+        handle_size[] = @ccall libwatcher.watcher_watcher_handle_sizeof()::Csize_t
+    end
+
+    s = handle_size[]
+
+    VariableSize{s}(Tuple(0 for _ = 1:s))
+end
 
 mutable struct Watcher
     cond::Base.AsyncCondition
     chan::Channel{Nothing}
-    watcher::Ptr{Nothing}
+    handle::VariableSize
 
     dir::String
 
-    Watcher(cond::Base.AsyncCondition, chan::Channel{Nothing}, watcher::Ptr{Nothing}, dir::AbstractString) =
-        finalizer(watcher_unsubscribe, new(cond, chan, watcher, dir))
+    Watcher(
+        cond::Base.AsyncCondition,
+        chan::Channel{Nothing},
+        handle::VariableSize,
+        dir::AbstractString,
+    ) = finalizer(watcher_unsubscribe, new(cond, chan, handle, dir))
 end
-Watcher(f::Function, ptr, dir::AbstractString) = Watcher(Base.AsyncCondition(f), ptr, dir)
+Watcher(f::Function, handle, dir::AbstractString) =
+    Watcher(Base.AsyncCondition(f), handle, dir)
 
 Base.show(io::IO, w::Watcher) = write(io, "Watcher(\"", w.dir, "\")")
 
@@ -19,25 +40,44 @@ Base.@kwdef struct Options
     backend = "default"
 end
 
-function watcher_write_snapshot(dir, snapshot_path)
-    @ccall libwatcher.watcher_write_snapshot(dir::Cstring, snapshot_path::Cstring)::Cvoid
+function watcher_write_snapshot(dir, snapshot_path, options)
+    @ccall libwatcher.watcher_write_snapshot(
+        dir::Cstring,
+        snapshot_path::Cstring,
+        options::Ptr{Nothing},
+    )::Cvoid
 end
 
-function watcher_get_events_since(dir, snapshot_path, events)
+function watcher_get_events_since(dir, snapshot_path, events, options)
     @ccall libwatcher.watcher_get_events_since(
         dir::Cstring,
         snapshot_path::Cstring,
         events::Ptr{Nothing},
+        options::Ptr{Nothing},
     )::Cvoid
 end
 
-function watcher_subscribe(dir, handle)
-    @ccall libwatcher.watcher_subscribe(dir::Cstring, handle::Ptr{Nothing})::Cvoid
+function watcher_subscribe(dir, handle, options, watcher_handle)
+    @ccall libwatcher.watcher_subscribe(
+        dir::Cstring,
+        handle::Ptr{Nothing},
+        options::Ptr{Nothing},
+        watcher_handle::Ptr{Nothing},
+    )::Cvoid
 end
-watcher_subscribe(w::Watcher) = watcher_subscribe(w.dir, w.cond.handle)
+function watcher_subscribe(w::Watcher, options)
+    GC.@preserve w watcher_subscribe(
+        w.dir,
+        w.cond.handle,
+        options,
+        Base.pointer_from_objref(w.handle),
+    )
+end
 
-function watcher_unsubscribe(dir)
-    @ccall libwatcher.watcher_unsubscribe(dir::Cstring)::Cvoid
+function watcher_unsubscribe(handle)
+    GC.@preserve handle @ccall libwatcher.watcher_unsubscribe(
+        Base.pointer_from_objref(handle)::Ptr{Cvoid},
+    )::Cvoid
 end
 
 function watcher_unsubscribe(watcher::Watcher)
@@ -45,7 +85,7 @@ function watcher_unsubscribe(watcher::Watcher)
         take!(watcher.chan)
         isopen(watcher.cond) || return
 
-        watcher_unsubscribe(watcher.dir) # FIXME: use watcher instead of dir
+        watcher_unsubscribe(watcher.handle)
         Base.close(watcher.cond)
     end
 
@@ -68,6 +108,11 @@ function watcher_watcher_get_events(watcher, events)
 end
 
 function to_options_ptr(options)
+    options = Options(
+        ignores = Set{String}(abspath(p) for p in options.ignores),
+        backend = options.backend,
+    )
+
     options_ptr = @ccall libwatcher.watcher_new_options()::Ptr{Nothing}
     for ignore in options.ignores
         @ccall libwatcher.watcher_options_add_ignore(
@@ -75,7 +120,7 @@ function to_options_ptr(options)
             ignore::Cstring,
         )::Ptr{Nothing}
     end
-    @ccall libwatcher.watcher_options_set_backend(
+    GC.@preserve options @ccall libwatcher.watcher_options_set_backend(
         options_ptr::Ptr{Nothing},
         options.backend::Cstring,
     )::Ptr{Nothing}
@@ -87,11 +132,15 @@ function watcher_delete_options(options)
     @ccall libwatcher.watcher_delete_options(options::Ptr{Nothing})::Cvoid
 end
 
+function watcher_delete_events(events)
+    @ccall libwatcher.watcher_delete_events(events::Ptr{Nothing})::Cvoid
+end
+
 struct JLEvent
     path::Ptr{Cchar}
     path_length::Csize_t
-    is_created::Bool
-    is_deleted::Bool
+    is_created::Cuchar
+    is_deleted::Cuchar
 end
 
 struct Event
@@ -107,38 +156,41 @@ Event(jl_event::JLEvent) = Event(
 
 function sanitize_path(path)
     length(path) == 0 && error("path can't be empty")
-    path # TODO
+    isdir(path) || error("path $path should be a directory")
+    abspath(path)
 end
 
 mutable struct Events
     size::Csize_t
     events::Ptr{JLEvent}
+
+    Events(size, events) = finalizer(
+        e -> begin
+            watcher_delete_events(Base.pointer_from_objref(e))
+        end,
+        new(size, events),
+    )
 end
 Events() = Events(0, Ptr{JLEvent}())
 
 function _get_events(watcher_ptr)
     events = Events()
-    GC.@preserve events watcher_watcher_get_events(
-        watcher_ptr,
+    GC.@preserve events watcher_ptr watcher_watcher_get_events(
+        Base.pointer_from_objref(watcher_ptr),
         Base.pointer_from_objref(events),
     )
     events.events == C_NULL && error("Failed to fetch events from watcher.")
 
-    raw_events = Base.unsafe_wrap(Array, events.events, events.size; own = true)
-
-    map(raw_events) do raw_event
-        event = Event(raw_event)
-        ccall(:free, Cvoid, (Ptr{Nothing},), raw_event.path)
-        event
+    GC.@preserve events begin
+        raw_events = Base.unsafe_wrap(Array, events.events, events.size)
+        Event.(raw_events)
     end
 end
 
 function subscribe(f::Function, dir, options = Options())
     dir = sanitize_path(dir)
 
-    options_ptr = to_options_ptr(options)
-    watcher_ptr = watcher_get_watcher(dir, options_ptr)
-    watcher_delete_options(options_ptr)
+    handle = WatcherHandle()
 
     chan = Channel{Nothing}(1)
     put!(chan, nothing)
@@ -146,7 +198,7 @@ function subscribe(f::Function, dir, options = Options())
     function callback(_)
         try
             take!(chan)
-            events = _get_events(watcher_ptr)
+            events = _get_events(handle)
             put!(chan, nothing)
 
             f(events)
@@ -156,9 +208,13 @@ function subscribe(f::Function, dir, options = Options())
     end
 
     cond = Base.AsyncCondition(callback)
-    watcher = Watcher(cond, chan, watcher_ptr, dir)
+    watcher = Watcher(cond, chan, handle, dir)
 
-    watcher_subscribe(watcher)
+    GC.@preserve options begin
+        options_ptr = to_options_ptr(options)
+        watcher_subscribe(watcher, options_ptr)
+        watcher_delete_options(options_ptr)
+    end
 
     watcher
 end
@@ -169,38 +225,67 @@ function unsubscribe(watcher)
     nothing
 end
 
-function write_snapshot(dir, snapshot_path)
-    dir = sanitize_path(dir)
-
-    watcher_write_snapshot(dir, snapshot_path)
+function validate_snapshot_path(path)
+    parent_path = abspath(path) |> dirname
+    if !isdir(parent_path)
+        error("Folder $parent_path does not exist for snapshot file $path")
+    end
+    length(path) == 0 && error("An empty path is not valid")
 end
 
-function get_events_since(dir, snapshot)
+"""
+    write_snapshot(dir::AbstractString, snapshot_path::AbstractString)::Nothing
+
+Writes a snapshot file to snaphot_path from the directory dir. The written snapshot can
+then be used with `get_events_since(dir, snapshot_path)` to retrieve the changes.
+"""
+function write_snapshot(dir, snapshot_path; options = Options())
     dir = sanitize_path(dir)
+    validate_snapshot_path(snapshot_path)
+
+    options_ptr = to_options_ptr(options)
+    watcher_write_snapshot(dir, snapshot_path, options_ptr)
+    watcher_delete_options(options_ptr)
+
+    nothing
+end
+
+"""
+get_events_since(dir::AbstractString, snapshot_path::AbstractString)::Vector{Event}
+
+"""
+function get_events_since(dir, snapshot_path; options = Options())
+    dir = sanitize_path(dir)
+    validate_snapshot_path(snapshot_path)
 
     events = Events()
-    GC.@preserve events watcher_get_events_since(
-        dir,
-        snapshot,
-        Base.pointer_from_objref(events),
-    )
-    events.events == C_NULL && error("Failed to get events since for '$snapshot'")
+    GC.@preserve events options begin
 
-    Base.unsafe_wrap(Array, events.events, events.size; own = true)
+        options_ptr = to_options_ptr(options)
+        watcher_get_events_since(
+            dir,
+            snapshot_path,
+            Base.pointer_from_objref(events),
+            options_ptr,
+        )
+        watcher_delete_options(options_ptr)
+        events.events == C_NULL && error("Failed to get events since for '$snapshot_path'")
+
+        Event.(Base.unsafe_wrap(Array, events.events, events.size))
+    end
 end
 
 "Synchronous API"
-function watch(f::Function, dir::AbstractString, options = Options())
+function watch_folder_sync(f::Function, dir::AbstractString; options = Options())
     dir = sanitize_path(dir)
 
-    options_ptr = to_options_ptr(options)
-    watcher_ptr = watcher_get_watcher(dir, options_ptr)
-    watcher_delete_options(options_ptr)
+    watcher_handle = WatcherHandle()
+
 
     cond = Base.AsyncCondition()
     chan = Channel{Nothing}(1)
     put!(chan, nothing)
-    w = Watcher(cond, chan, watcher_ptr, dir)
+    w = Watcher(cond, chan, watcher_handle, dir)
 
     task = Task() do
         try
@@ -208,7 +293,7 @@ function watch(f::Function, dir::AbstractString, options = Options())
                 wait(cond)
 
                 take!(chan)
-                events = _get_events(watcher_ptr)
+                events = _get_events(watcher_handle)
                 put!(chan, nothing)
                 f(events)
             end
@@ -217,7 +302,11 @@ function watch(f::Function, dir::AbstractString, options = Options())
         end
     end
 
-    watcher_subscribe(w)
+    GC.@preserve options begin
+        options_ptr = to_options_ptr(options)
+        watcher_subscribe(w, options_ptr)
+        watcher_delete_options(options_ptr)
+    end
 
     schedule(task)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ macro asynclog(expr)
 	end
 end
 
-
+include("./snapshots.jl")
 
 @testset "Basic - $(method)" for method in ["new", "legacy"]
     test_dir = tempname(cleanup=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,11 +55,13 @@ end
             push!(events, e)
         end
     else
-        @asynclog while true
+        @info "using legacy"
+        t = @async while true
             e = watch_folder(test_dir)
             @info "Event" e
             push!(events, e)
         end
+        t
     end
 
     sleep(2)
@@ -98,4 +100,3 @@ end
     sleep(2)
     @test_nowarn schedule(watch_task, InterruptException(); error=true)
 end
-

--- a/test/snapshots.jl
+++ b/test/snapshots.jl
@@ -1,0 +1,55 @@
+@enum Action Modify Create Delete
+
+@testset "Snapshots" begin
+
+    @testset "write/get" begin
+        tmp_dir = mktempdir()
+
+        write_file(p, content) = write(joinpath(tmp_dir, p), content)
+        delete_file(p) = rm(joinpath(tmp_dir, p))
+
+        write_file("not_modified.txt", "sticky")
+        write_file("already_existing.txt", "Hello")
+        write_file("should_be_deleted.txt", "oh no")
+
+        snapshot_file = joinpath(tmp_dir, "snapshot.txt")
+        BetterFileWatching.write_snapshot(tmp_dir, snapshot_file)
+
+        delete_file("should_be_deleted.txt")
+        write_file("already_existing.txt", "modified")
+        write_file("newly_created.txt", "hey!")
+
+        events = BetterFileWatching.get_events_since(tmp_dir, snapshot_file)
+
+        @test count(events) do event
+            basename(event.path) == "should_be_deleted.txt" &&
+                event.is_deleted &&
+                !event.is_created
+        end == 1
+
+        @test count(events) do event
+            basename(event.path) == "newly_created.txt" &&
+                !event.is_deleted &&
+                event.is_created
+        end == 1
+
+        @test count(events) do event
+            basename(event.path) == "already_existing.txt" &&
+                !event.is_deleted &&
+                !event.is_created
+        end == 1
+
+        @test count(events) do event
+            basename(event.path) == "not_modified.txt"
+        end == 0
+    end
+
+    @testset "Errors" begin
+        tmp_dir = mktempdir()
+        @test_throws ErrorException BetterFileWatching.write_snapshot(tmp_dir, "")
+
+        @test_throws ErrorException BetterFileWatching.write_snapshot(tmp_dir, joinpath(tmp_dir, "notafolder/mysnapshot.txt"))
+
+        @test_throws ErrorException BetterFileWatching.write_snapshot("not_existing.folder", "")
+    end
+end


### PR DESCRIPTION
More information on the [updated readme for BetterFileWatching.jl](https://github.com/JuliaPluto/BetterFileWatching.jl/tree/libwatcher) and at [JuliaPluto/watcher](https://github.com/JuliaPluto/watcher/tree/julia_port#readme).

###### Todos:
 - [ ] Crashes on windows :thinking:
 - [ ] `Options(ignores = Set([".git/"]))` has no effect