### PR TITLE
Use `open` instead of `@async run`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BetterFileWatching"
 uuid = "c9fd44ac-77b5-486c-9482-9798bd063cc6"
 authors = ["Fons van der Plas <fons@plutojl.org>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Deno_jll = "04572ae6-984a-583e-9378-9577a1c2574d"

--- a/src/BetterFileWatching.jl
+++ b/src/BetterFileWatching.jl
@@ -115,18 +115,11 @@ function watch_folder(on_event::Function, dir::AbstractString="."; ignore_access
     catch e
         Base.process_running(deno_proc) || Base.kill(deno_proc)
         if !(e isa InterruptException)
-            showerror(stderr, e, catch_backtrace())
-        end
-    end
-    
-    try
-        wait(watch_task)
-    catch e
-        Base.process_running(deno_proc) || Base.kill(deno_proc)
-        if !(e isa InterruptException)
             @error "BetterFileWatching error" exception=(e,catch_backtrace())
         end
     end
+    
+    try wait(watch_task) catch; end
 end
 
 

--- a/src/BetterFileWatching.jl
+++ b/src/BetterFileWatching.jl
@@ -1,6 +1,6 @@
 module BetterFileWatching
 
-using Deno_jll
+import Deno_jll: deno
 
 import JSON
 
@@ -80,6 +80,7 @@ function watch_folder(on_event::Function, dir::AbstractString="."; ignore_access
             try {
                 await Deno.stdout.write(new TextEncoder().encode("\\n" + JSON.stringify(event) + "\\n"));
             } catch(e) {
+                console.error("Error while writing changes to stdout", e);
                 Deno.exit();
             }
         }
@@ -105,22 +106,27 @@ function watch_folder(on_event::Function, dir::AbstractString="."; ignore_access
         end
     end
 
-    deno_task = @async run(pipeline(`$(deno()) eval $(script)`; stdout=outpipe))
+    deno_proc = open(pipeline(`$(deno()) eval $(script)`; stdout=outpipe))
+    atexit(() -> Base.kill(deno_proc))
     watch_task = @async try
-        sleep(.1)
         while true
             on_stdout(String(readavailable(outpipe)))
         end
     catch e
-        if !istaskdone(deno_task)
-            schedule(deno_task, e; error=true)
-        end
+        Base.process_running(deno_proc) || Base.kill(deno_proc)
         if !(e isa InterruptException)
             showerror(stderr, e, catch_backtrace())
         end
     end
     
-    try wait(watch_task) catch; end
+    try
+        wait(watch_task)
+    catch e
+        Base.process_running(deno_proc) || Base.kill(deno_proc)
+        if !(e isa InterruptException)
+            @error "BetterFileWatching error" exception=(e,catch_backtrace())
+        end
+    end
 end
 
 


### PR DESCRIPTION
I learned this API from @Pangoraw in Malt.jl!

This also fixes a silent error when running on platforms that don't support Deno_jll (the `deno()` function would not exist but the error was silent).

This also means that we can remove the `sleep(.1)` :)