### PR TITLE
Bump dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,8 @@ Deno_jll = "04572ae6-984a-583e-9378-9577a1c2574d"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-Deno_jll = "^1.10"
-JSON = "^0.20, ^0.21"
+Deno_jll = "2"
+JSON = "1"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ watch_file(f::Function, filename=".")
 
 Watch a file for changes. A [`FileEvent`](@ref) is passed to the callback function `f`.
 
+
+### `FileEvent`
+The object passed to the callback function `f` is a `FileEvent`. This is a supertype, with the following subtypes:
+
+```
+julia> BetterFileWatching.FileEvent |> subtypes
+7-element Vector{Any}:
+ BetterFileWatching.Accessed
+ BetterFileWatching.AnyEvent
+ BetterFileWatching.Created
+ BetterFileWatching.Modified
+ BetterFileWatching.Other
+ BetterFileWatching.Removed
+ BetterFileWatching.Renamed
+```
+
+Each of these types as a `.paths` field, which is a vector of strings. This is the path of the file or folder that changed. In practice, the `AnyEvent` and `Other` occur only rarely, as a fallback when the specific event type is not known.
+
 # Example
 
 ```julia

--- a/src/BetterFileWatching.jl
+++ b/src/BetterFileWatching.jl
@@ -7,6 +7,15 @@ import JSON
 
 abstract type FileEvent end
 
+struct AnyEvent <: FileEvent
+    paths::Vector{String}
+end
+struct Accessed <: FileEvent
+    paths::Vector{String}
+end
+struct Created <: FileEvent
+    paths::Vector{String}
+end
 struct Modified <: FileEvent
     paths::Vector{String}
 end
@@ -16,19 +25,19 @@ end
 struct Removed <: FileEvent
     paths::Vector{String}
 end
-struct Created <: FileEvent
-    paths::Vector{String}
-end
-struct Accessed <: FileEvent
+struct Other <: FileEvent
     paths::Vector{String}
 end
 
+# These should match https://docs.deno.com/api/deno/~/Deno.FsEvent
 const mapFileEvent = Dict(
+    "any" => AnyEvent,
+    "access" => Accessed,
+    "create" => Created,
     "modify" => Modified,
     "rename" => Renamed,
-    "create" => Created,
     "remove" => Removed,
-    "access" => Accessed,
+    "other" => Other,
 )
 
 export watch_folder, watch_file

--- a/src/BetterFileWatching.jl
+++ b/src/BetterFileWatching.jl
@@ -10,6 +10,9 @@ abstract type FileEvent end
 struct Modified <: FileEvent
     paths::Vector{String}
 end
+struct Renamed <: FileEvent
+    paths::Vector{String}
+end
 struct Removed <: FileEvent
     paths::Vector{String}
 end
@@ -22,6 +25,7 @@ end
 
 const mapFileEvent = Dict(
     "modify" => Modified,
+    "rename" => Renamed,
     "create" => Created,
     "remove" => Removed,
     "access" => Accessed,


### PR DESCRIPTION
I wanted to use this package for recursive folder watching but then had incompatible version requirements because I was using `JSON.jl` >= v1.0.
Hence, I bumped the `compat` entries for this package. Feel free to make them tighter if I was too liberal with just the major versions here.

When running the tests, I noticed that Deno has introduced a new file event `rename`, so I added it to this package as well.