### PR TITLE
[codex] Use scalar path fields for file events

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -131,7 +131,7 @@ cancel(src)   # watch_folder cleans up and returns
 
 `CancellationTokens.take!(channel, token)` throws `OperationCanceledException` on cancel — exactly the hook we
 need to unblock the event loop and tear down the uv handle. Ran cleanly; events mapped to
-BetterFileWatching-style `Created`/`Modified`/`Removed` structs with `.paths`.
+BetterFileWatching-style `Created`/`Modified`/`Removed` structs with `.path`.
 
 ## Experiment 4 — Linux scaling numbers ✅
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ julia> BetterFileWatching.FileEvent |> subtypes
  BetterFileWatching.Renamed
 ```
 
-`Created`, `Modified`, `Removed`, and `Other` each have a `.path::String` field with the absolute path of the file or folder that changed. `Renamed` has `.from::String` and `.to::String` fields when the OS lets us pair the rename.
+`Created`, `Modified`, `Removed`, and `Other` each have a `.path::String` field with the absolute path of the file or folder that changed. `Renamed` has `.from::String` and `.to::String` fields when the OS lets us pair the rename. Use `paths_tuple(event)` to handle both shapes uniformly: it returns `(event.path,)` for single-path events and `(event.from, event.to)` for renames.
 
 Event *kinds* are best-effort: precise on Linux and Windows, coarser on macOS (an append to an existing file may surface as `Created`). Event paths are always reliable. Delivery is at-least-once, so make your callback idempotent.
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ julia> BetterFileWatching.FileEvent |> subtypes
  BetterFileWatching.Renamed
 ```
 
-Each of these types has a `.paths` field, which is a vector of strings: the absolute path(s) of the file or folder that changed. For `Renamed`, `paths` is `[from, to]` when the OS lets us pair the rename.
+`Created`, `Modified`, `Removed`, and `Other` each have a `.path::String` field with the absolute path of the file or folder that changed. `Renamed` has `.from::String` and `.to::String` fields when the OS lets us pair the rename.
 
-Event *kinds* are best-effort: precise on Linux and Windows, coarser on macOS (an append to an existing file may surface as `Created`). Paths are always reliable. Delivery is at-least-once, so make your callback idempotent.
+Event *kinds* are best-effort: precise on Linux and Windows, coarser on macOS (an append to an existing file may surface as `Created`). Event paths are always reliable. Delivery is at-least-once, so make your callback idempotent.
 
 # Example
 

--- a/src/BetterFileWatching.jl
+++ b/src/BetterFileWatching.jl
@@ -23,7 +23,8 @@ using CancellationTokens: CancellationToken, CancellationTokenSource,
     OperationCanceledException, get_token, cancel
 
 export watch_folder, watch_file,
-    FileEvent, Created, Modified, Removed, Renamed, Other
+    FileEvent, Created, Modified, Removed, Renamed, Other,
+    paths_tuple
 
 # ─── event types ─────────────────────────────────────────────────────────────
 
@@ -70,9 +71,18 @@ struct Other <: FileEvent
 end
 
 _event_key(e::FileEvent) = e.path
-_event_key(e::Renamed) = (e.from, e.to)
+_event_key(e::Renamed) = paths_tuple(e)
 _event_involves(e::FileEvent, path::String) = e.path == path
 _event_involves(e::Renamed, path::String) = e.from == path || e.to == path
+
+"""
+    paths_tuple(event::FileEvent)
+
+Return the path or paths involved in `event` as a tuple. Single-path events
+return `(event.path,)`; renames return `(event.from, event.to)`.
+"""
+paths_tuple(e::FileEvent) = (e.path,)
+paths_tuple(e::Renamed) = (e.from, e.to)
 
 Base.:(==)(a::FileEvent, b::FileEvent) = typeof(a) === typeof(b) && _event_key(a) == _event_key(b)
 Base.hash(e::FileEvent, h::UInt) = hash(_event_key(e), hash(typeof(e), h))

--- a/src/BetterFileWatching.jl
+++ b/src/BetterFileWatching.jl
@@ -25,11 +25,12 @@ using CancellationTokens: CancellationToken, CancellationTokenSource,
 export watch_folder, watch_file,
     FileEvent, Created, Modified, Removed, Renamed, Other
 
-# ─── event types (BetterFileWatching ≤ 0.1 compatible shape) ─────────────────
+# ─── event types ─────────────────────────────────────────────────────────────
 
 """
-Abstract supertype of all watch events. Every event has a
-`paths::Vector{String}` field with the absolute path(s) it concerns.
+Abstract supertype of all watch events. `Created`, `Modified`, `Removed`, and
+`Other` each have a `path::String` field with the absolute path they concern.
+`Renamed` has `from::String` and `to::String` fields.
 
 Event *kinds* are best-effort and platform-dependent: precise on Linux and
 Windows, coarser on macOS (where e.g. an append to an existing file may
@@ -40,35 +41,41 @@ abstract type FileEvent end
 
 "A file or directory appeared."
 struct Created <: FileEvent
-    paths::Vector{String}
+    path::String
 end
 
 "File contents or metadata changed."
 struct Modified <: FileEvent
-    paths::Vector{String}
+    path::String
 end
 
 "A file or directory was deleted."
 struct Removed <: FileEvent
-    paths::Vector{String}
+    path::String
 end
 
-"A rename was observed. When the OS lets us pair it, `paths` is `[from, to]`."
+"A paired rename from one absolute path to another was observed."
 struct Renamed <: FileEvent
-    paths::Vector{String}
+    from::String
+    to::String
 end
 
 """
 Fallback event. Currently emitted when the kernel event queue overflowed:
-some events were lost and `paths` is the watch root — rescan if you need
-exact state.
+some events were lost and `path` is the watch root — rescan if you need exact
+state.
 """
 struct Other <: FileEvent
-    paths::Vector{String}
+    path::String
 end
 
-Base.:(==)(a::FileEvent, b::FileEvent) = typeof(a) === typeof(b) && a.paths == b.paths
-Base.hash(e::FileEvent, h::UInt) = hash(e.paths, hash(typeof(e), h))
+_event_key(e::FileEvent) = e.path
+_event_key(e::Renamed) = (e.from, e.to)
+_event_involves(e::FileEvent, path::String) = e.path == path
+_event_involves(e::Renamed, path::String) = e.from == path || e.to == path
+
+Base.:(==)(a::FileEvent, b::FileEvent) = typeof(a) === typeof(b) && _event_key(a) == _event_key(b)
+Base.hash(e::FileEvent, h::UInt) = hash(_event_key(e), hash(typeof(e), h))
 
 include("common.jl")
 include("backend_uv.jl")
@@ -94,7 +101,7 @@ tree (and its contents), however deep.
 
 `latency` is the coalescing window in seconds: after the first event arrives,
 we wait this long for stragglers, then merge the batch — exact duplicates are
-suppressed and rename pairs are stitched into `Renamed([from, to])` where the
+suppressed and rename pairs are stitched into `Renamed(from, to)` where the
 OS allows. Editors save files in bursts (write-tmpfile-then-rename dances);
 the window collapses those into fewer, better events. Set `latency = 0` to
 dispatch every event immediately.
@@ -179,9 +186,7 @@ function _watch(
             end
             for event in _merge_batch(batch)
                 if filter_path !== nothing
-                    paths = filter(==(filter_path), event.paths)
-                    isempty(paths) && continue
-                    event = (typeof(event))(paths)
+                    _event_involves(event, filter_path) || continue
                 end
                 f(event)
             end

--- a/src/backend_inotify.jl
+++ b/src/backend_inotify.jl
@@ -116,7 +116,7 @@ function _watch_tree!(w::InotifyBackend, dir::String, out::Union{Nothing,Vector{
     for name in entries
         full = joinpath(dir, name)
         _isignored(w.ignore, relpath(full, w.root)) && continue
-        out === nothing || push!(out, Created([full]))
+        out === nothing || push!(out, Created(full))
         if isdir(full)
             haskey(w.dir_to_wd, full) || _add_watch!(w, full)
             _watch_tree!(w, full, out)
@@ -246,7 +246,7 @@ function _dispatch!(w::InotifyBackend, raws::Vector{RawInotifyEvent})
     for raw in raws
         if (raw.mask & IN_Q_OVERFLOW) != 0
             _resync!(w)
-            push!(out, Other([w.root]))
+            push!(out, Other(w.root))
             continue
         end
         if (raw.mask & IN_IGNORED) != 0
@@ -272,26 +272,26 @@ function _dispatch!(w::InotifyBackend, raws::Vector{RawInotifyEvent})
             from = pop!(pending_from, raw.cookie, nothing)
             if from === nothing
                 # moved in from outside the tree: brand-new content
-                push!(out, Created([full]))
+                push!(out, Created(full))
                 isdir_ && _on_new_dir!(w, full, out)
             else
-                push!(out, Renamed([from, full]))
+                push!(out, Renamed(from, full))
                 # renamed within the tree: watches came along, fix bookkeeping
                 isdir_ && w.recursive && _rename_tree!(w, from, full)
             end
         elseif (raw.mask & IN_CREATE) != 0
-            push!(out, Created([full]))
+            push!(out, Created(full))
             isdir_ && _on_new_dir!(w, full, out)
         elseif (raw.mask & IN_DELETE) != 0
-            push!(out, Removed([full]))
+            push!(out, Removed(full))
         elseif (raw.mask & (IN_MODIFY | IN_CLOSE_WRITE | IN_ATTRIB)) != 0
-            push!(out, Modified([full]))
+            push!(out, Modified(full))
         end
     end
 
     # A MOVED_FROM whose pair never arrived (moved outside the tree) = removal.
     for from in values(pending_from)
-        push!(out, Removed([from]))
+        push!(out, Removed(from))
         w.recursive && _evict_tree!(w, from)
     end
 

--- a/src/backend_uv.jl
+++ b/src/backend_uv.jl
@@ -29,7 +29,7 @@ function _uv_fseventscb(handle::Ptr{Cvoid}, filename::Ptr{Int8}, events::Int32, 
     # libuv only distinguishes "change" (contents) from "rename" (appeared /
     # disappeared / renamed). We sample existence here and let the batch merge
     # step pair rename hints into `Renamed` or degrade them to Created/Removed.
-    event = (events & UV_CHANGE) != 0 ? Modified([full]) : RenameHint(full, ispath(full))
+    event = (events & UV_CHANGE) != 0 ? Modified(full) : RenameHint(full, ispath(full))
     _offer!(t.channel, event)
     return nothing
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -46,13 +46,13 @@ function _collect_batch!(batch::Vector{Any}, ch::Channel, token, latency::Real)
 end
 
 # Merge a batch: pair rename hints, and drop an event when the previous event
-# for the same path(s) was identical. Duplicates are inherent to at-least-once
+# for the same path key was identical. Duplicates are inherent to at-least-once
 # delivery — the Linux new-directory rescan synthesizes Created events that
 # the kernel may also report — but a genuine create → remove → create must
-# survive, so we compare against the last event per path, not a global set.
+# survive, so we compare against the last event per key, not a global set.
 function _merge_batch(batch::Vector{Any})
     out = FileEvent[]
-    last_for = Dict{Vector{String},FileEvent}()
+    last_for = Dict{Any,FileEvent}()
     i = firstindex(batch)
     while i <= lastindex(batch)
         x = batch[i]
@@ -60,18 +60,19 @@ function _merge_batch(batch::Vector{Any})
             next = i < lastindex(batch) ? batch[i+1] : nothing
             if !x.existed && next isa RenameHint && next.existed && next.path != x.path
                 i += 1   # consume the pair
-                Renamed([x.path, next.path])
+                Renamed(x.path, next.path)
             elseif x.existed
-                Created([x.path])
+                Created(x.path)
             else
-                Removed([x.path])
+                Removed(x.path)
             end
         else
             x::FileEvent
         end
-        if get(last_for, event.paths, nothing) != event
+        key = _event_key(event)
+        if get(last_for, key, nothing) != event
             push!(out, event)
-            last_for[event.paths] = event
+            last_for[key] = event
         end
         i += 1
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,8 +34,7 @@ function with_watcher(body::Function, dir::AbstractString; kwargs...)
     end
 end
 
-involves(ev::FileEvent, p) = ev.path == p
-involves(ev::Renamed, p) = ev.from == p || ev.to == p
+involves(ev::FileEvent, p) = p in paths_tuple(ev)
 haspath(events, p) = any(ev -> involves(ev, p), events)
 haspath(events, p, T::Type) = any(ev -> ev isa T && involves(ev, p), events)
 
@@ -43,18 +42,12 @@ newroot() = realpath(mktempdir())
 
 @testset "BetterFileWatching" begin
 
-    @testset "event fields" begin
-        @test fieldnames(Created) == (:path,)
-        @test fieldnames(Modified) == (:path,)
-        @test fieldnames(Removed) == (:path,)
-        @test fieldnames(Other) == (:path,)
-        @test fieldtype(Created, :path) == String
-        @test fieldtype(Modified, :path) == String
-        @test fieldtype(Removed, :path) == String
-        @test fieldtype(Other, :path) == String
-        @test fieldnames(Renamed) == (:from, :to)
-        @test fieldtype(Renamed, :from) == String
-        @test fieldtype(Renamed, :to) == String
+    @testset "paths_tuple" begin
+        @test paths_tuple(Created("/r/a")) == ("/r/a",)
+        @test paths_tuple(Modified("/r/a")) == ("/r/a",)
+        @test paths_tuple(Removed("/r/a")) == ("/r/a",)
+        @test paths_tuple(Other("/r")) == ("/r",)
+        @test paths_tuple(Renamed("/r/a", "/r/b")) == ("/r/a", "/r/b")
     end
 
     @testset "batch merging (unit)" begin
@@ -145,7 +138,7 @@ newroot() = realpath(mktempdir())
         with_watcher(root) do get_events
             mv(f_old, f_new)
             if Sys.islinux()
-                @test await(() -> any(ev -> ev isa Renamed && ev.from == f_old && ev.to == f_new, get_events()))
+                @test await(() -> any(ev -> ev isa Renamed && paths_tuple(ev) == (f_old, f_new), get_events()))
             else
                 # coarse platforms: at least both paths show up
                 @test await(() -> haspath(get_events(), f_new))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,43 +34,59 @@ function with_watcher(body::Function, dir::AbstractString; kwargs...)
     end
 end
 
-haspath(events, p) = any(ev -> p in ev.paths, events)
-haspath(events, p, T::Type) = any(ev -> ev isa T && p in ev.paths, events)
+involves(ev::FileEvent, p) = ev.path == p
+involves(ev::Renamed, p) = ev.from == p || ev.to == p
+haspath(events, p) = any(ev -> involves(ev, p), events)
+haspath(events, p, T::Type) = any(ev -> ev isa T && involves(ev, p), events)
 
 newroot() = realpath(mktempdir())
 
 @testset "BetterFileWatching" begin
 
+    @testset "event fields" begin
+        @test fieldnames(Created) == (:path,)
+        @test fieldnames(Modified) == (:path,)
+        @test fieldnames(Removed) == (:path,)
+        @test fieldnames(Other) == (:path,)
+        @test fieldtype(Created, :path) == String
+        @test fieldtype(Modified, :path) == String
+        @test fieldtype(Removed, :path) == String
+        @test fieldtype(Other, :path) == String
+        @test fieldnames(Renamed) == (:from, :to)
+        @test fieldtype(Renamed, :from) == String
+        @test fieldtype(Renamed, :to) == String
+    end
+
     @testset "batch merging (unit)" begin
         a, b = "/r/a", "/r/b"
 
         # exact duplicates are suppressed, even when not adjacent
-        @test _merge_batch(Any[Created([a]), Created([b]), Created([a])]) ==
-              [Created([a]), Created([b])]
+        @test _merge_batch(Any[Created(a), Created(b), Created(a)]) ==
+              [Created(a), Created(b)]
 
         # ...but a genuine create → remove → create survives
-        @test _merge_batch(Any[Created([a]), Removed([a]), Created([a])]) ==
-              [Created([a]), Removed([a]), Created([a])]
+        @test _merge_batch(Any[Created(a), Removed(a), Created(a)]) ==
+              [Created(a), Removed(a), Created(a)]
 
         # adjacent rename hints (gone, then present) pair into Renamed
         @test _merge_batch(Any[RenameHint(a, false), RenameHint(b, true)]) ==
-              [Renamed([a, b])]
+              [Renamed(a, b)]
 
         # unpaired hints degrade by existence
-        @test _merge_batch(Any[RenameHint(a, true)]) == [Created([a])]
-        @test _merge_batch(Any[RenameHint(a, false)]) == [Removed([a])]
+        @test _merge_batch(Any[RenameHint(a, true)]) == [Created(a)]
+        @test _merge_batch(Any[RenameHint(a, false)]) == [Removed(a)]
 
         # same-path disappear + reappear is not a rename
         @test _merge_batch(Any[RenameHint(a, false), RenameHint(a, true)]) ==
-              [Removed([a]), Created([a])]
+              [Removed(a), Created(a)]
 
         # wrong order (present, then gone) does not pair
         @test _merge_batch(Any[RenameHint(a, true), RenameHint(b, false)]) ==
-              [Created([a]), Removed([b])]
+              [Created(a), Removed(b)]
 
         # a Modified between hints breaks adjacency — no false pair
-        @test _merge_batch(Any[RenameHint(a, false), Modified([b]), RenameHint(b, true)]) ==
-              [Removed([a]), Modified([b]), Created([b])]
+        @test _merge_batch(Any[RenameHint(a, false), Modified(b), RenameHint(b, true)]) ==
+              [Removed(a), Modified(b), Created(b)]
     end
 
     @testset "recursive watching" begin
@@ -129,7 +145,7 @@ newroot() = realpath(mktempdir())
         with_watcher(root) do get_events
             mv(f_old, f_new)
             if Sys.islinux()
-                @test await(() -> any(ev -> ev isa Renamed && ev.paths == [f_old, f_new], get_events()))
+                @test await(() -> any(ev -> ev isa Renamed && ev.from == f_old && ev.to == f_new, get_events()))
             else
                 # coarse platforms: at least both paths show up
                 @test await(() -> haspath(get_events(), f_new))
@@ -207,7 +223,7 @@ newroot() = realpath(mktempdir())
             @test await(() -> lock(() -> haspath(events, target), lk))
             sleep(0.5)
             snapshot = lock(() -> copy(events), lk)
-            @test all(ev -> ev.paths == [target], snapshot)
+            @test all(ev -> involves(ev, target), snapshot)
             @test !haspath(snapshot, sibling)
         finally
             cancel(src)


### PR DESCRIPTION
_Generated by AI 🤖_

## Summary

- Replace vector-backed event paths with scalar fields: `path::String` for single-path events and `from::String` / `to::String` for `Renamed`.
- Add exported `paths_tuple(event::FileEvent)` for tuple-based access across single-path and rename events.
- Update merge, deduplication, backend constructors, `watch_file` filtering, README docs, and tests for the new shape.

## Validation

- `julia --project=. -e "using Pkg; Pkg.test()"`

_Generated by AI 🤖_