### PR TITLE
Add code coverage reporting via Codecov

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -42,3 +42,13 @@ jobs:
             - uses: julia-actions/julia-buildpkg@v1
 
             - uses: julia-actions/julia-runtest@v1
+              with:
+                  coverage: true
+
+            - uses: julia-actions/julia-processcoverage@v1
+
+            - uses: codecov/codecov-action@v5
+              with:
+                  files: lcov.info
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BetterFileWatching.jl
 
 [![Julia tests](https://github.com/JuliaPluto/BetterFileWatching.jl/actions/workflows/Test.yml/badge.svg)](https://github.com/JuliaPluto/BetterFileWatching.jl/actions/workflows/Test.yml)
+[![codecov](https://codecov.io/gh/JuliaPluto/BetterFileWatching.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaPluto/BetterFileWatching.jl)
 
 ```julia
 watch_folder(f::Function, dir=".")


### PR DESCRIPTION
_Generated by AI 🤖_

Runs the test suite with coverage enabled, processes the results with `julia-actions/julia-processcoverage`, and uploads to Codecov. Also adds a coverage badge to the README.

Opened to test that the `CODECOV_TOKEN` secret works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)